### PR TITLE
Make buffer initialization slightly more concise

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -64,8 +64,7 @@ fn split_read_zerocopy<R, F>(
         where R: Read, F: FnMut(&[u8]) -> Result<()> {
 
     // Initialize the buffer
-    let mut buf = Vec::<u8>::with_capacity(pagesize() * 2);
-    buf.resize(buf.capacity(), 0);
+    let mut buf = vec![0u8; pagesize() * 2];
 
     // Amount of data actually in the buffer (manually managed so we
     // can avoid reinitializing all the data when we resize)

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,7 @@ fn split_read_zerocopy<R, F>(
         where R: Read, F: FnMut(&[u8]) -> Result<()> {
 
     // Initialize the buffer
-    let mut buf = vec![0u8; pagesize() * 2];
+    let mut buf = vec![0u8; pagesize() * 2]; // buf.capacity() == buf.len() == pagesize() * 2
 
     // Amount of data actually in the buffer (manually managed so we
     // can avoid reinitializing all the data when we resize)


### PR DESCRIPTION
Hello 😃, 

First of all, I really enjoyed and learned a lot from [your article on Medium](https://medium.com/adobetech/filtering-duplicates-on-the-command-line-30x-faster-than-sort-uniq-96ca5f7b4277)! 
Thank you for sharing your experience 👍 

The PR contains a trivial fix that makes the buffer initialization slightly more concise.
(with same semantics as before)

Below are relevant comments from 
`https://github.com/rust-lang/rust/blob/master/src/liballoc/vec.rs`
> /// The [`vec!`] macro is provided to make initialization more convenient:
///
/// ```
/// let mut vec = vec![1, 2, 3];
/// vec.push(4);
/// assert_eq!(vec, [1, 2, 3, 4]);
/// ```
///
/// It can also initialize each element of a `Vec<T>` with a given value.
/// This may be more efficient than performing allocation and initialization
/// in separate steps, especially when initializing a vector of zeros:
///
/// ```
/// let vec = vec![0; 5];
/// assert_eq!(vec, [0, 0, 0, 0, 0]);
///
/// // The following is equivalent, but potentially slower:
/// let mut vec1 = Vec::with_capacity(5);
/// vec1.resize(5, 0);

Please feel free to close the PR if you don't like the fix.