### PR TITLE
 Remove extra BufReader, BufWriter, type fish 

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,15 @@
 mod xxhash;
 mod xxhash_bindings;
 
-use std::collections::{HashSet, HashMap, hash_map};
-use std::hash::{Hasher, BuildHasher};
-use std::io::{stdin, Read, BufRead, BufReader, stdout, Write, BufWriter, ErrorKind};
-use std::{slice, default::Default, marker::PhantomData};
-use sysconf::page::pagesize;
-use anyhow::Result;
-use clap::{Arg, App};
-use getrandom::getrandom;
 use crate::xxhash::xxh3_u64_secret;
-
+use anyhow::Result;
+use clap::{App, Arg};
+use getrandom::getrandom;
+use std::collections::{hash_map, HashMap, HashSet};
+use std::hash::{BuildHasher, Hasher};
+use std::io::{stdin, stdout, BufRead, BufReader, BufWriter, ErrorKind, Read, Write};
+use std::{default::Default, marker::PhantomData, slice};
+use sysconf::page::pagesize;
 
 /// A no-operation hasher. Used as part of the uniq implementation,
 /// because in there we manually hash the data and just store the
@@ -24,7 +23,8 @@ struct IdentityHasher {
 impl Hasher for IdentityHasher {
     fn write(&mut self, bytes: &[u8]) {
         self.off += (&mut self.buf[self.off as usize..])
-            .write(bytes).unwrap_or(0) as u8;
+            .write(bytes)
+            .unwrap_or(0) as u8;
     }
 
     fn finish(&self) -> u64 {
@@ -58,11 +58,11 @@ impl<H: Hasher + Default> BuildHasher for BuildDefaultHasher<H> {
 /// The tokens found will be passed to the given callback. The tokens will
 /// always be terminated by the delimiter at the end. Even if the last token
 /// is delimited by eof and not the delimiter, a delimiter will be supplied.
-fn split_read_zerocopy<R, F>(
-        delim: u8, inp: &mut R, mut handle_line: F)
-        -> Result<()>
-        where R: Read, F: FnMut(&[u8]) -> Result<()> {
-
+fn split_read_zerocopy<R, F>(delim: u8, inp: &mut R, mut handle_line: F) -> Result<()>
+where
+    R: Read,
+    F: FnMut(&[u8]) -> Result<()>,
+{
     // Initialize the buffer
     let mut buf = vec![0u8; pagesize() * 2]; // buf.capacity() == buf.len() == pagesize() * 2
 
@@ -73,10 +73,11 @@ fn split_read_zerocopy<R, F>(
     loop {
         match inp.read(&mut buf[used..] /* unused space */) {
             Err(ref e) if e.kind() == ErrorKind::Interrupted =>
-                // EINTR – thrown when a process receives a signal…
-                continue,
-            Err(e) =>
-                return Err(anyhow::Error::from(e)),
+            // EINTR – thrown when a process receives a signal…
+            {
+                continue
+            }
+            Err(e) => return Err(anyhow::Error::from(e)),
             Ok(0) => {
                 // EOF; we potentially need to process the last word here
                 // if the input is missing a newline (or rather delim) at
@@ -94,16 +95,19 @@ fn split_read_zerocopy<R, F>(
                 }
 
                 break;
-            }, Ok(len) =>
-                // Register the data that became available
+            }
+            Ok(len) =>
+            // Register the data that became available
+            {
                 used += len
+            }
         };
 
         // Scan the buffer for lines
         let mut line_start: usize = 0;
         for (off, chr) in (&buf[..used]).iter().enumerate() {
             if *chr == delim {
-                handle_line(&buf[line_start..off+1])?;
+                handle_line(&buf[line_start..off + 1])?;
                 line_start = off + 1;
             }
         }
@@ -130,8 +134,12 @@ fn count_cmd(delim: u8) -> Result<()> {
     let mut set = HashMap::<Vec<u8>, u64>::new();
     for line in BufReader::new(stdin().lock()).split(delim) {
         match set.entry(line?) {
-            hash_map::Entry::Occupied(mut e) => { *e.get_mut() += 1; },
-            hash_map::Entry::Vacant(e)   => { e.insert(1); }
+            hash_map::Entry::Occupied(mut e) => {
+                *e.get_mut() += 1;
+            }
+            hash_map::Entry::Vacant(e) => {
+                e.insert(1);
+            }
         }
     }
 
@@ -159,7 +167,7 @@ fn uniq_cmd(delim: u8) -> Result<()> {
     getrandom(&mut secret)?;
 
     split_read_zerocopy(delim, &mut inp.lock(), |line| {
-        let tok: &[u8] = &line[..line.len()-1];
+        let tok: &[u8] = &line[..line.len() - 1];
         if set.insert(xxh3_u64_secret(&tok, &secret)) {
             out.write(&line)?;
         }
@@ -169,49 +177,55 @@ fn uniq_cmd(delim: u8) -> Result<()> {
     Ok(())
 }
 
-
 fn try_main() -> Result<()> {
     let mut argspec = App::new("huniq")
         .version("2.1.0")
         .about("Remove duplicates from stdin, using a hash table")
         .author("Karolin Varner <karo@cupdev.net)")
-        .arg(Arg::with_name("count")
-            .help("Output the amount of times a line was encountered")
-            .long("count")
-            .short("c"))
-        .arg(Arg::with_name("delimiter")
-            .help("Which delimiter between elements to use. By default `\n` is used")
-            .long("delimiter")
-            .long("delim")
-            .short("d")
-            .takes_value(true)
-            .default_value("\n")
-            .validator(|v| match v.len() {
-                1 => Ok(()),
-                _ => Err(String::from("\
+        .arg(
+            Arg::with_name("count")
+                .help("Output the amount of times a line was encountered")
+                .long("count")
+                .short("c"),
+        )
+        .arg(
+            Arg::with_name("delimiter")
+                .help("Which delimiter between elements to use. By default `\n` is used")
+                .long("delimiter")
+                .long("delim")
+                .short("d")
+                .takes_value(true)
+                .default_value("\n")
+                .validator(|v| match v.len() {
+                    1 => Ok(()),
+                    _ => Err(String::from(
+                        "\
 Only ascii characters are supported as delimiters. \
 Use sed to turn your delimiter into zero bytes?
 
     $ echo -n \"1λ1λ2λ3\" | sed 's@λ@\x00@g' | huniq -0 | sed 's@\x00@λ@g'
-    1λ2λ3λ"
-                ))
-            }))
-        .arg(Arg::with_name("null")
-            .help("Use the \\0 character as the record delimiter.")
-            .long("null")
-            .short("0")
-            .conflicts_with("delimiter"));
+    1λ2λ3λ",
+                    )),
+                }),
+        )
+        .arg(
+            Arg::with_name("null")
+                .help("Use the \\0 character as the record delimiter.")
+                .long("null")
+                .short("0")
+                .conflicts_with("delimiter"),
+        );
 
     let args = argspec.get_matches_from_safe_borrow(&mut std::env::args_os())?;
 
     let delim = match args.is_present("null") {
-            true  => b'\0',
-            false => args.value_of("delimiter").unwrap().as_bytes()[0]
+        true => b'\0',
+        false => args.value_of("delimiter").unwrap().as_bytes()[0],
     };
 
     match args.is_present("count") {
-        true  => count_cmd(delim),
-        false => uniq_cmd(delim)
+        true => count_cmd(delim),
+        false => uniq_cmd(delim),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use clap::{App, Arg};
 use getrandom::getrandom;
 use std::collections::{hash_map, HashMap, HashSet};
 use std::hash::{BuildHasher, Hasher};
-use std::io::{stdin, stdout, BufRead, BufReader, BufWriter, ErrorKind, Read, Write};
+use std::io::{stdin, stdout, BufRead, ErrorKind, Read, Write};
 use std::{default::Default, marker::PhantomData, slice};
 use sysconf::page::pagesize;
 
@@ -132,7 +132,7 @@ where
 /// the number of occurrences.
 fn count_cmd(delim: u8) -> Result<()> {
     let mut set = HashMap::<Vec<u8>, u64>::new();
-    for line in BufReader::new(stdin().lock()).split(delim) {
+    for line in stdin().lock().split(delim) {
         match set.entry(line?) {
             hash_map::Entry::Occupied(mut e) => {
                 *e.get_mut() += 1;
@@ -144,7 +144,7 @@ fn count_cmd(delim: u8) -> Result<()> {
     }
 
     let out = stdout();
-    let mut out = BufWriter::new(out.lock());
+    let mut out = out.lock();
     for (line, count) in set.iter() {
         write!(out, "{} ", count)?;
         out.write(&line)?;
@@ -159,7 +159,7 @@ fn uniq_cmd(delim: u8) -> Result<()> {
     // Line processing/output ///////////////////////
     let out = stdout();
     let inp = stdin();
-    let mut out = BufWriter::new(out.lock());
+    let mut out = out.lock();
     let mut set = HashSet::<u64, BuildDefaultHasher<IdentityHasher>>::default();
 
     // Mitigate hash collision attacks by using a random seed


### PR DESCRIPTION
The title is what I set out to do but I set up my editor so it auto-formats the source and before I realized I made all my fixes based on `rustfmt` formatted code 😞 

I decided to at least separate out the formatting change to its own commit. If you don't like it let me know.