### PR TITLE
Search delimiter with memchr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,7 @@ dependencies = [
  "cc",
  "clap",
  "getrandom",
+ "memchr",
  "shell-words",
  "sysconf",
 ]
@@ -267,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.3.0"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3197e20c7edb283f87c071ddfc7a2cca8f8e0b888c242959846a6fce03c72223"
+checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "nom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ clap = "^2.33.0"
 anyhow = "^1.0.26"
 sysconf = "^0.3.4"
 getrandom = "^0.1.14"
+memchr = "2.3.3"
 
 [build-dependencies]
 bindgen = "^0.52.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use anyhow::Result;
 use clap::{Arg, App};
 use getrandom::getrandom;
 use crate::xxhash::xxh3_u64_secret;
+use memchr::memchr_iter;
 
 
 /// A no-operation hasher. Used as part of the uniq implementation,
@@ -101,11 +102,9 @@ fn split_read_zerocopy<R, F>(
 
         // Scan the buffer for lines
         let mut line_start: usize = 0;
-        for (off, chr) in (&buf[..used]).iter().enumerate() {
-            if *chr == delim {
-                handle_line(&buf[line_start..off+1])?;
-                line_start = off + 1;
-            }
+        for off in memchr_iter(delim, &buf[..used]) {
+            handle_line(&buf[line_start..off+1])?;
+            line_start = off + 1;
         }
 
         // Move the current line fragment to the start of the buffer


### PR DESCRIPTION
_“The [memchr](https://crates.io/crates/memchr) crate provides heavily optimized routines for searching bytes”_ (quoting their README).

On my machine it improves performance of ~15%.
Also it's a minimal change and IMHO it actually simplifies the code.