### PR TITLE
Implement -s,--sort and -S,--sort-descending for output ordering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7825f6833612eb2414095684fcf6c635becf3ce97fe48cf6421321e93bfbd53c"
 
 [[package]]
+name = "assert_cmd"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c88b9ca26f9c16ec830350d309397e74ee9abdfd8eb1f71cb6ecc71a3fc818da"
+dependencies = [
+ "doc-comment",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,6 +135,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "env_logger"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +226,7 @@ name = "huniq"
 version = "2.3.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "bindgen",
  "cc",
  "clap",
@@ -287,6 +313,32 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "predicates"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96bfead12e90dccead362d62bb2c90a5f6fc4584963645bc7f71a735e0b0735a"
+dependencies = [
+ "difference",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06075c3a3e92559ff8929e7a280684489ea27fe44805174c3ebd9328dcb37178"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e63c4859013b38a76eca2414c64911fba30def9e3202ac461a2d22831220124"
+dependencies = [
+ "predicates-core",
+ "treeline",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -397,6 +449,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "treeline"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -419,6 +477,15 @@ name = "version_check"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,6 @@ bindgen = "^0.52.0"
 cc = { version = "^1.0.48", features = ["parallel"] }
 anyhow = "^1.0.26"
 shell-words = "^0.1.0"
+
+[dev-dependencies]
+assert_cmd = "1.0.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -211,7 +211,7 @@ fn uniq_cmd(delim: u8) -> Result<()> {
 
 fn try_main() -> Result<()> {
     let mut argspec = App::new("huniq")
-        .version("2.1.0")
+        .version(env!("CARGO_PKG_VERSION"))
         .about("Remove duplicates from stdin, using a hash table")
         .author("Karolin Varner <karo@cupdev.net)")
         .arg(

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,0 +1,31 @@
+use assert_cmd::{assert::Assert, Command};
+
+#[test]
+fn noargs() {
+    assert("", &[]).success().stdout("");
+}
+
+#[test]
+fn duplicate_line() {
+    assert("a\na\na\n", &[]).success().stdout("a\n");
+}
+
+#[test]
+fn unique_lines() {
+    assert("a\nb\nc\n", &[]).success().stdout("a\nb\nc\n");
+}
+
+#[test]
+fn count_sort() {
+    assert("a\na\nb\n", &["-c", "-s"]).success().stdout("1 b\n2 a\n");
+}
+
+#[test]
+fn count_sort_descending() {
+    assert("a\na\nb\n", &["-c", "-S"]).success().stdout("2 a\n1 b\n");
+}
+
+fn assert(input: &str, args: &[&str]) -> Assert {
+    let mut cmd = Command::cargo_bin("huniq").unwrap();
+    cmd.args(args).write_stdin(input).assert()
+}


### PR DESCRIPTION
Fixes #9 , as I've also found the need to have a sorting option myself.

The flag names are those suggested in #9, but that's open to bikeshedding.