### PR TITLE
Exit without freeing memory on success

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "huniq"
-version = "2.4.1"
+version = "2.5.0"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ bstr = "0.2.14"
 
 [dev-dependencies]
 assert_cmd = "1.0.1"
+
+[profile.release]
+lto = "fat"

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /usr/bin/env bash
 
 set -e
 trap "exit" SIGINT SIGTERM # exit from loop

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use std::collections::{hash_map, HashMap, HashSet};
 use std::hash::BuildHasherDefault;
 use std::hash::{BuildHasher, Hasher};
 use std::io::{stdin, stdout, BufRead, Write};
+use std::mem;
 use std::{default::Default, slice};
 
 /// A no-operation hasher. Used as part of the uniq implementation,
@@ -57,11 +58,15 @@ fn count_cmd(delim: u8, sort: Option<Sort>) -> Result<()> {
         }
     }
 
-    if let Some(sort) = sort {
+    let result = if let Some(sort) = sort {
         sort_and_print(delim, sort, &set)
     } else {
         print_out(delim, set.iter().map(|(k, v)| (k.as_slice(), *v)))
-    }
+    };
+
+    mem::forget(set); // app can now exit, so we don't need to wait for this memory to be freed piecemeal
+
+    result
 }
 
 type DataAndCount<'a> = (&'a [u8], u64);
@@ -115,6 +120,8 @@ fn uniq_cmd(delim: u8, include_trailing: bool) -> Result<()> {
         }
         Ok(true)
     })?;
+
+    mem::forget(set); // app can now exit, so we don't need to wait for this memory to be freed piecemeal
 
     Ok(())
 }


### PR DESCRIPTION
fixes #17 

I haven't done the benchmarking yet. The speedups should show especially in repeated runs with `-c` for inputs with large amounts of unique lines.

Also includes small cleanups for Cargo.lock, and uses `std::hash::BuildHasherDefault`. If I misunderstood the purpose of the custom implementation of `BuildDefaultHasher` I can drop the commit, it just looked identical to me.