### PR TITLE
Update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "huniq"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "ahash",
  "anyhow",


### PR DESCRIPTION
`Cargo.toml` was updated in [1e4d1f2](https://github.com/koraa/huniq/commit/1e4d1f23bbb88c34f7c128f7eb4a500e97eabf4b) but the version in `Cargo.lock` is outdated.
