### PR TITLE
Use github actions to automatically create github release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,8 @@ jobs:
         with:
           command: build
           args: --release
+      - name: Rename file 
+        run: mv target/release/huniq target/release/huniq_x86-64
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
@@ -24,4 +26,4 @@ jobs:
           prerelease: true
           title: "Development Build"
           files: |
-            target/release/huniq
+            target/release/huniq_x86-64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,27 @@
+on:
+  workflow_dispatch:
+  push:
+
+name: CI
+
+jobs:
+  build_and_test:
+    name: Rust project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "latest"
+          prerelease: true
+          title: "Development Build"
+          files: |
+            target/release/huniq


### PR DESCRIPTION
Added an example GitHub action that will build and upload the compiled binary as a GitHub release - as seen here: https://github.com/Phasip/huniq/releases/tag/latest

The action executes on every push and can also be manually launched.